### PR TITLE
OOTP-502 Update name according to new guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AutoUpdate Manager
+# AutoUpdate Manager Sample 
 This Sample App enables you to control your OneAgent AutoUpdate settings per host group at large scale. It introduces the concept of "macros" as meta-configuration to enable automation-assisted tasks.
 
 ## This app demonstrates

--- a/app.config.ts
+++ b/app.config.ts
@@ -5,7 +5,7 @@ const config: CliOptions = {
   environmentUrl: "https://xxxxxxx.apps.dynatrace.com/",
   icon: "src/assets/Au.png",
   app: {
-    name: "AutoUpdate Manager",
+    name: "AutoUpdate Manager Sample",
     version: "0.0.22",
     description: "A Sample App which enables controlling AutoUpdate at large scale",
     id: "my.auto.update.manager",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -62,7 +62,7 @@ export const App = () => {
           <Flex flexDirection="row" alignItems="center">
             <Flex flexDirection="column" gap={16}>
               <Flex gap={4} flexDirection="column">
-                <Heading>AutoUpdate Manager</Heading>
+                <Heading>AutoUpdate Manager Sample</Heading>
                 {!hideAds && (
                   <Text>
                     This Sample App enables you to control your OneAgent <AutoUpdateTerminology /> settings per host


### PR DESCRIPTION
Update the name to "AutoUpdate Manager Sample" according to new naming guidelines.
